### PR TITLE
Optimize Shrinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Integer lessThanNBCouldBeNegative = g.anyIntegerLessThan(n).get();
 ```
 
 #### Seed and variable management
-One really important aspect of generative testing is making sure you can reproduce a test that fails so that you can find and fix the issue. Generating values from a Generative object ensures you use a consistent seed for a given test, and always prints the seed of a failing test in the exception message. Additionally, for getting nice error reports, you can name variables:
+One really important aspect of generative testing is making sure you can reproduce a test that fails so that you can find and fix the issue. Generating values from a Generative object ensures you use a consistent seed for a given test, and always prints the seed of a failing test in the exception message. Additionally, for getting nice error reports and to enable shrinking, you can name variables:
 ```java
  runTests(100, (testNumber, g) -> {
         Integer theInt = g.namedVar("The Number").anyPositiveIntegerLessThan(50).get();
@@ -64,7 +64,7 @@ These seeds can be passed as additional arguments to `runTests` to ensure that o
 
 #### Shrinking
 
-Often a random test will find some edge case, but the data used to find that case will be excessivly large or complicated for figuring out exactly what went wrong. Generatvie implements a primitive form of _shrinking_, which is simplifying input data to find the simplest possible test case that still fails. Generative provides the following interface:
+Often a random test will find some edge case, but the data used to find that case will be excessivly large or complicated for figuring out exactly what went wrong. Generative implements a primitive form of _shrinking_, which is simplifying input data to find the simplest possible test case that still fails. Generative provides the following interface:
 ```java
 public interface Arbitrary<T> {
 
@@ -91,6 +91,8 @@ public interface Arbitrary<T> {
   }
 ```
 This method tries to simplify the test case by using 0 if it's within the bounds and then the bounds themselves to try to find a case that's easier to understand. Alternative values should be provided from simplest to least simple, as the library will use the first value that still fails the test.
+
+It's important to note that Generative will only shrink variables which have been named using the the `namedVar` syntax described above. 
 
 ### Advanced Usage of Arbitrary
 

--- a/generative_core/src/main/java/com/liveramp/generative/Arbitrary.java
+++ b/generative_core/src/main/java/com/liveramp/generative/Arbitrary.java
@@ -94,4 +94,8 @@ public interface Arbitrary<T> {
         Function.identity(),
         Fixed::new);
   }
+
+  default String prettyPrint(T val) {
+    return val.toString();
+  }
 }

--- a/generative_core/src/main/java/com/liveramp/generative/ArbitraryByteArray.java
+++ b/generative_core/src/main/java/com/liveramp/generative/ArbitraryByteArray.java
@@ -8,14 +8,18 @@ import java.util.Random;
 
 public class ArbitraryByteArray implements Arbitrary<byte[]> {
 
-  private int length;
+  private Arbitrary<Integer> length;
 
   public ArbitraryByteArray(int length) {
+    this(new Fixed<>(length));
+  }
+
+  public ArbitraryByteArray(Arbitrary<Integer> length) {
     this.length = length;
   }
 
   public byte[] get(Random r) {
-    byte[] result = new byte[length];
+    byte[] result = new byte[length.get(r)];
     r.nextBytes(result);
     return result;
   }
@@ -23,18 +27,26 @@ public class ArbitraryByteArray implements Arbitrary<byte[]> {
   @Override
   public List<byte[]> shrink(byte[] val) {
     List<byte[]> result = new ArrayList<>();
-    Collections.addAll(result,
-        makeArrayOf(0),
-        makeArrayOf(1),
-        makeArrayOf(Byte.MIN_VALUE),
-        makeArrayOf(Byte.MAX_VALUE)
-    );
+    for (Integer shrunkLength : length.shrink(val.length)) {
+      Collections.addAll(result,
+          makeArrayOf(0, shrunkLength),
+          makeArrayOf(1, shrunkLength),
+          makeArrayOf(Byte.MIN_VALUE, shrunkLength),
+          makeArrayOf(Byte.MAX_VALUE, shrunkLength)
+      );
+    }
+
     return result;
   }
 
-  private byte[] makeArrayOf(int i) {
+  private byte[] makeArrayOf(int i, int length) {
     byte[] zeroArray = new byte[length];
     Arrays.fill(zeroArray, (byte)i);
     return zeroArray;
+  }
+
+  @Override
+  public String prettyPrint(byte[] val) {
+    return Arrays.toString(val);
   }
 }

--- a/generative_core/src/main/java/com/liveramp/generative/Generative.java
+++ b/generative_core/src/main/java/com/liveramp/generative/Generative.java
@@ -250,11 +250,7 @@ public class Generative {
       block.run(testNumber, gen);
     } catch (Throwable e) {
       if (!shouldShrink) {
-        StringBuilder vars = new StringBuilder("Generated variables were: \n");
-        for (Pair<String, Object> entry : gen.generated) {
-          vars.append(entry.getKey() + " : " + entry.getValue() + "\n");
-        }
-        LOG.info(vars.toString());
+        logGeneratedNamedVars(gen);
         throw new RuntimeException(e);
       } else {
         Pair<String, Throwable> shrinkSeed = shrink(seed, testNumber, gen.index.get(), block);
@@ -266,6 +262,14 @@ public class Generative {
         }
       }
     }
+  }
+
+  private static void logGeneratedNamedVars(Generative gen) {
+    StringBuilder vars = new StringBuilder("Generated variables were: \n");
+    for (Pair<String, Object> entry : gen.generated) {
+      vars.append(entry.getKey() + " : " + entry.getValue() + "\n");
+    }
+    LOG.info(vars.toString());
   }
 
   private static void runTestWithSeed(String seed, int testNumber, TestBlock block) {
@@ -341,11 +345,7 @@ public class Generative {
       }
     }
     LOG.info("Returning shrunken test case - performed " + (shrinkTestNumber - testNumber) + " shrinks");
-    StringBuilder vars = new StringBuilder("Generated variables were: \n");
-    for (Pair<String, Object> entry : gen.generated) {
-      vars.append(entry.getKey() + " : " + entry.getValue() + "\n");
-    }
-    LOG.info(vars.toString());
+    logGeneratedNamedVars(gen);
     return Pair.of(seed + ":" + toString(shrinks), lastException);
   }
 }


### PR DESCRIPTION
The previous implementation tried to shrink all variables, and needed to run at least 1 test case per variable, even in cases where that variable did not provide shrink candidates. The new implementation shrinks all variables at the outset, and only tries to shrink variables that have been provided a name. This is to ensure correctness (the previous index-based approach was prone to certain errors) and to ensure only variables that can actually be reported on are being shrunk.