### PR TITLE
Set `optional` fields sometimes but not others

### DIFF
--- a/generative_thrift/src/main/java/com/liveramp/generative/ArbitraryThrift.java
+++ b/generative_thrift/src/main/java/com/liveramp/generative/ArbitraryThrift.java
@@ -58,7 +58,10 @@ public class ArbitraryThrift<T extends TBase> implements Arbitrary<T> {
       for (Map.Entry<? extends TFieldIdEnum, FieldMetaData> entry : entries) {
         Optional<Arbitrary> maybeArbitrary = getArbitrary(entry);
         if (maybeArbitrary.isPresent()) {
-          t.setFieldValue(entry.getKey(), maybeArbitrary.get().get(r));
+          // For required fields we always set them, but for optional fields, it's a coin-flip
+          if (r.nextBoolean() || entry.getValue().requirementType ==  TFieldRequirementType.REQUIRED) {
+            t.setFieldValue(entry.getKey(), maybeArbitrary.get().get(r));
+          }
         }
       }
       if (!(t instanceof TUnion)) {


### PR DESCRIPTION
We'll correctly always set a `required` field, but if a field is
`optional` or `default`, we'll only occasionally set it. `default`
requiredness doesn't have perfect language support, so I haven't
actually thought through the implications. Frankly, it should be
deprecated if anyone's using it.